### PR TITLE
Fix ktheod/OneDriveBully#13 by adding recursive search and junction support

### DIFF
--- a/OneDriveBully/MyFunctions.cs
+++ b/OneDriveBully/MyFunctions.cs
@@ -283,7 +283,7 @@ namespace OneDriveBully
             SymLinksTable.Columns.Add("Folder Name", typeof(string));
 
             Properties.Settings.Default.Reload();
-            string[] subDirs = Directory.GetDirectories(Properties.Settings.Default.OneDriveRootFolder);
+            string[] subDirs = Directory.GetDirectories(Properties.Settings.Default.OneDriveRootFolder, "*", SearchOption.AllDirectories);
 
             SymbolicLink sl = new SymbolicLink();
 

--- a/OneDriveBully/SymbolicLink.cs
+++ b/OneDriveBully/SymbolicLink.cs
@@ -6,10 +6,23 @@ using System.Text;
 
 namespace OneDriveBully
 {
+    public interface IReparseData
+    {
+        uint GetReparseTag { get; }
+
+        ushort GetPrintNameOffset { get; }
+
+        byte[] GetPathBuffer { get; }
+
+        ushort GetPrintNameLength { get; }
+
+        uint ExpectedReparseTag { get; }
+    }
+
     // For More Details about this Class, please visit http://troyparsons.com/blog/2012/03/symbolic-links-in-c-sharp/
 
     [StructLayout(LayoutKind.Sequential)]
-    public struct SymbolicLinkReparseData
+    public struct SymbolicLinkReparseData : IReparseData
     {
         // Not certain about this!
         private const int maxUnicodePathLength = 260 * 2;
@@ -24,8 +37,36 @@ namespace OneDriveBully
         public uint Flags;
         [MarshalAs(UnmanagedType.ByValArray, SizeConst = maxUnicodePathLength)]
         public byte[] PathBuffer;
+
+        public uint GetReparseTag => ReparseTag;
+        public ushort GetPrintNameOffset => PrintNameOffset;
+        public byte[] GetPathBuffer => PathBuffer;
+        public ushort GetPrintNameLength => PrintNameLength;
+        public uint ExpectedReparseTag => 0xA000000C;
     }
 
+    [StructLayout(LayoutKind.Sequential)]
+    public struct MountPointReparseData : IReparseData
+    {
+        // Not certain about this!
+        private const int maxUnicodePathLength = 260 * 2;
+
+        public uint ReparseTag;
+        public ushort ReparseDataLength;
+        public ushort Reserved;
+        public ushort SubstituteNameOffset;
+        public ushort SubstituteNameLength;
+        public ushort PrintNameOffset;
+        public ushort PrintNameLength;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = maxUnicodePathLength)]
+        public byte[] PathBuffer;
+
+        public uint GetReparseTag => ReparseTag;
+        public ushort GetPrintNameOffset => PrintNameOffset;
+        public byte[] GetPathBuffer => PathBuffer;
+        public ushort GetPrintNameLength => PrintNameLength;
+        public uint ExpectedReparseTag => 0xA0000003;
+    }
 
     public class SymbolicLink
     {
@@ -40,8 +81,6 @@ namespace OneDriveBully
         private const uint pathNotAReparsePointError = 0x80071126;
 
         private const uint shareModeAll = 0x7; // Read, Write, Delete
-
-        private const uint symLinkTag = 0xA000000C;
 
         private const int targetIsAFile = 0;
 
@@ -111,11 +150,27 @@ namespace OneDriveBully
         }
         public string GetSymLinkTarget(string path)
         {
-            return GetTarget(path);
+            string result = GetTarget<SymbolicLinkReparseData>(path);
+
+            // If we couldn't get a symlink, try getting a mount point
+            if (string.IsNullOrEmpty(result))
+            {
+                result = GetTarget<MountPointReparseData>(path);
+            }
+
+            return result;
         }
+
+        // Old version of this method with no generic parameter for compatibility
+        // It assumes that symlink is desired, which is the old functionality.
         public static string GetTarget(string path)
         {
-            SymbolicLinkReparseData reparseDataBuffer;
+            return GetTarget<SymbolicLinkReparseData>(path);
+        }
+
+        public static string GetTarget<TReparseData>(string path) where TReparseData : IReparseData
+        {
+            TReparseData reparseDataBuffer;
 
             using (SafeFileHandle fileHandle = getFileHandle(path))
             {
@@ -145,21 +200,21 @@ namespace OneDriveBully
                         Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
                     }
 
-                    reparseDataBuffer = (SymbolicLinkReparseData)Marshal.PtrToStructure(
-                        outBuffer, typeof(SymbolicLinkReparseData));
+                    reparseDataBuffer = (TReparseData)Marshal.PtrToStructure(
+                        outBuffer, typeof(TReparseData));
                 }
                 finally
                 {
                     Marshal.FreeHGlobal(outBuffer);
                 }
             }
-            if (reparseDataBuffer.ReparseTag != symLinkTag)
+            if (reparseDataBuffer.GetReparseTag != reparseDataBuffer.ExpectedReparseTag)
             {
                 return null;
             }
 
-            string target = Encoding.Unicode.GetString(reparseDataBuffer.PathBuffer,
-                reparseDataBuffer.PrintNameOffset, reparseDataBuffer.PrintNameLength);
+            string target = Encoding.Unicode.GetString(reparseDataBuffer.GetPathBuffer,
+                reparseDataBuffer.GetPrintNameOffset, reparseDataBuffer.GetPrintNameLength);
 
             return target;
         }


### PR DESCRIPTION
I modified the app to find directories recursively, instead of just top-level, which I think solves @WardenHub's problem in ktheod/OneDriveBully#13.

However, even once I did that, the app could not detect the target path of my junctions. That's because the app ignores any reparse data not associated with a symlink, so it ignores the junction info. I was hoping that the data buffers would be compatible, so that I would just have to add a check for the mount point tag, but unfortunately they are slightly different.

Symbolic Link buffer: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/b41f1cbf-10df-4a47-98d4-1c52a833d913

Junction (aka mount point) buffer: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/ca069dad-ed16-42aa-b057-b6b207f447cc

My solution was to modify GetTarget so that it can retrieve either symlink or mount point data, based on a given generic parameter. Now it works like a charm for my use case!

Please note that I _only_ tested this with junctions, so if you are considering merging, please retest with your existing symlinks.

